### PR TITLE
Add methods to enable or disable all modules at the same time.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -84,3 +84,17 @@ function disableModule(command) {
     module.enabled = false;
   }
 }
+
+/**
+ * Enable all existing modules, call their onEnable() lifecycle function.
+ */
+function enableModules() {
+    modules.forEach((module, command) => enableModule(command));
+}
+
+/**
+ * Disable all enabled modules, call their onDisable() lifecycle function.
+ */
+function disableModules() {
+    modules.forEach((module, command) => disableModule(command));
+}


### PR DESCRIPTION
`enableModules()` function is intended for calling when the whole bot has been deployed.

`disableModules()` function is intended for calling when the whole bot has been stopped or when we manually want to disable all of them. 
