### PR TITLE
WIP: Add module class example

### DIFF
--- a/src/core-class-example.js
+++ b/src/core-class-example.js
@@ -1,0 +1,27 @@
+class Module {
+  constructor(command) {
+    if (!command || typeof command !== 'string') {
+      throw Error('Command must be a string.');
+    }
+    this.command = command;
+    this.enabled = true;
+  }
+
+  onReceive() {
+    console.log('onReceive');
+  }
+
+  onEnable() {
+    console.log('onEnable');
+  }
+
+  onDisable() {
+    console.log('onDisable');
+  }
+}
+
+class SupaModule extends Module {
+  constructor(command) {
+    super(command);
+  }
+}

--- a/src/core-class-example.js
+++ b/src/core-class-example.js
@@ -1,11 +1,4 @@
 class Module {
-  constructor(command) {
-    if (!command || typeof command !== 'string') {
-      throw Error('Command must be a string.');
-    }
-    this.enabled = true;
-  }
-
   onReceive(sender) {
     console.log('onReceive');
   }
@@ -19,8 +12,4 @@ class Module {
   }
 }
 
-class SupaModule extends Module {
-  constructor(command) {
-    super(command);
-  }
-}
+class SupaModule extends Module {}

--- a/src/core-class-example.js
+++ b/src/core-class-example.js
@@ -6,15 +6,15 @@ class Module {
     this.enabled = true;
   }
 
-  onReceive() {
+  onReceive(sender) {
     console.log('onReceive');
   }
 
-  onEnable() {
+  onEnable(sender) {
     console.log('onEnable');
   }
 
-  onDisable() {
+  onDisable(sender) {
     console.log('onDisable');
   }
 }

--- a/src/core-class-example.js
+++ b/src/core-class-example.js
@@ -1,15 +1,29 @@
 class Module {
-  onReceive(sender, args = []) {
+
+  constructor(sender) {
+    this.sender = sender;
+  }
+
+  onReceive(args = []) {
     console.log('onReceive');
   }
 
-  onEnable(sender) {
+  onEnable() {
     console.log('onEnable');
   }
 
-  onDisable(sender) {
+  onDisable() {
     console.log('onDisable');
   }
 }
 
-class SupaModule extends Module {}
+class SupaModule extends Module {
+  onReceive(args = []) {
+    console.log('onReceive: with args ' + args);
+    this.sender.send('I never asked for this.');
+  }
+}
+
+// core.js
+const modules = new Map();
+map.set('/superstart', new SupaModule({send:args => console.log(args);}));

--- a/src/core-class-example.js
+++ b/src/core-class-example.js
@@ -3,7 +3,6 @@ class Module {
     if (!command || typeof command !== 'string') {
       throw Error('Command must be a string.');
     }
-    this.command = command;
     this.enabled = true;
   }
 

--- a/src/core-class-example.js
+++ b/src/core-class-example.js
@@ -1,5 +1,5 @@
 class Module {
-  onReceive(sender) {
+  onReceive(sender, args = []) {
     console.log('onReceive');
   }
 


### PR DESCRIPTION
__Not for merge.__

Here is an experimental class-based implementation of module. Please, review and share ideas.

Pros:
- every module has all lifecycle methods by default
- every module passed to `ModuleRegistry` (`core`) is valid by default

Cons:
- API consumers have to know how to work with ES6 classes