### PR TITLE
Add module template

### DIFF
--- a/project-template/index.template.js
+++ b/project-template/index.template.js
@@ -1,1 +1,17 @@
-console.log('I am the bot.');
+const { registerModule } = require('nay');
+
+function onReceive(sender) {
+  // TODO
+}
+
+function onEnable() {
+  // TODO
+}
+
+function onDisable() {
+  // TODO
+}
+
+const module = { onReceive, onEnable, onDisable };
+
+registerModule('/command', module);


### PR DESCRIPTION
I wrote an example of possible module API usage.

I realised that with functional API style we don't have any way to enable/disable modules. With OOP style we could call `moduleInstance.disable()`.

Do you remember how `setTimeout` and `clearTimeout` functions in JavaScript work? I think we can use the same technique here to be able to enable/disable modules on demand:
```js
const { registerModule, enableModule, disableModule } = require('nay');
...
const moduleId = registerModule('/command', module);
disableModule(moduleId);
enableModule(moduleId);
```